### PR TITLE
Categories

### DIFF
--- a/handlers/accounts-id.js
+++ b/handlers/accounts-id.js
@@ -32,13 +32,13 @@ const GET_HANDLER = async (request, h) => {
   }
 
   let userID = request.auth.credentials.user_id
-  let authorized = account.props.userIDs.includes(userID)
+  let authorized = account.userIDs.includes(userID)
   if (!authorized)
     throw boom.unauthorized()
 
   return {
     id: account.id,
-    user_ids: account.props.userIDs
+    user_ids: account.userIDs
   }
 }
 

--- a/handlers/accounts.js
+++ b/handlers/accounts.js
@@ -38,7 +38,7 @@ const GET_HANDLER = async (request, h) => {
 
   return accounts.map(account => ({
     id: account.id,
-    user_ids: account.props.userIDs
+    user_ids: account.userIDs
   }))
 }
 
@@ -52,7 +52,7 @@ const POST_HANDLER = async (request, h) => {
 
   return {
     id: account.id,
-    user_ids: account.props.userIDs
+    user_ids: account.userIDs
   }
 }
 

--- a/handlers/categories-id.js
+++ b/handlers/categories-id.js
@@ -42,7 +42,7 @@ const DELETE_RESPONSES = {
 
 const VALIDATE_ACCOUNT = async (accountID, userID) => {
   let account = await Time.Account.fetch(accountID)
-  let authorized = account.props.userIDs.includes(userID)
+  let authorized = account.userIDs.includes(userID)
   if (!authorized) throw boom.unauthorized()
 }
 
@@ -68,7 +68,7 @@ const HANDLER = async (request, h) => {
 
 const FORMAT_CATEGORY = (category) => ({
   id: category.id,
-  parent_id: category.props.parent_id,
+  parent_id: category.parent_id,
   account_id: category.account_id,
   name: category.name
 })

--- a/handlers/categories-id.js
+++ b/handlers/categories-id.js
@@ -1,0 +1,155 @@
+const joi = require('joi')
+const boom = require('boom')
+const Time = require('time-core')()
+
+exports.path = '/categories/{id}'
+
+const GET_DESCRIPTION = 'Fetch a Category'
+const GENERAL_RESPONSES = {
+  '200': {
+    'description': 'Success',
+    'schema': joi.object().keys({
+      id: joi.number().integer(),
+      parent_id: joi.number().integer(),
+      account_id: joi.number().integer(),
+      name: joi.string(),
+    })
+  },
+  '400': {
+    'description': 'Bad request. Invalid user input'
+  },
+  '401': {
+    'description': 'Unauthorized. Resources are not available to user.'
+  },
+  '500': {
+    'description': 'Server Error'
+  }
+}
+
+const PUT_DESCRIPTION = 'Update a Category'
+const DELETE_DESCRIPTION = 'Delete a Category'
+const DELETE_RESPONSES = {
+  '200': {
+    'description': 'Success',
+    'schema': joi.object().keys({
+      success: joi.boolean()
+    })
+  },
+  '500': {
+    'description': 'Server Error'
+  }
+}
+
+const VALIDATE_ACCOUNT = async (accountID, userID) => {
+  let account = await Time.Account.fetch(accountID)
+  let authorized = account.props.userIDs.includes(userID)
+  if (!authorized) throw boom.unauthorized()
+}
+
+const HANDLER = async (request, h) => {
+  let userID = request.auth.credentials.user_id
+  let categoryID = request.params.id
+  let category = await Time.Category.fetch(categoryID).catch(() => { throw boom.notFound() })
+
+  await VALIDATE_ACCOUNT(category.account_id, userID)
+
+  switch (request.method) {
+    case 'get':
+      return FORMAT_CATEGORY(category)
+    case 'put':
+      let validatedPayload = await VALIDATE_PUT(userID, request.payload)
+      return await HANDLE_PUT(category, validatedPayload)
+    case 'delete':
+      return HANDLE_DELETE(category, request.payload)
+    default:
+      return boom.badImplementation()
+  }
+}
+
+const FORMAT_CATEGORY = (category) => ({
+  id: category.id,
+  parent_id: category.props.parent_id,
+  account_id: category.account_id,
+  name: category.name
+})
+
+const VALIDATE_PUT = async (userID, payload) => {
+  let validatedPayload = Object.assign({}, payload)
+
+  if (payload.account_id)
+    await VALIDATE_ACCOUNT(payload.account_id, userID)
+
+  if (payload.parent_id) {
+    let parent = await Time.Category.fetch(payload.parent_id)
+    await VALIDATE_ACCOUNT(parent.account_id, userID)
+
+    // Avoid pulling data twice
+    validatedPayload.parent = parent
+  }
+
+  return validatedPayload
+}
+
+const HANDLE_PUT = async (category, payload) => {
+  if (payload.name) category.name = payload.name
+  if (payload.account_id) category.account = payload.account_id
+  if (payload.parent) category.parent = payload.parent
+
+  try {
+    await category.save()
+  } catch (err) {
+    switch (err) {
+      case Time.Error.Category.INCONSISTENT_PARENT_AND_ACCOUNT:
+        throw boom.badRequest('Mismatched Parent and Account IDs')
+      default:
+        throw boom.badImplementation()
+    }
+  }
+
+  return FORMAT_CATEGORY(category)
+}
+
+const HANDLE_DELETE = async (category, payload) => {
+  let deleteChildren = (payload || {}).delete_children || false
+  await category.delete(deleteChildren)
+  return { success: true }
+}
+
+const PUT_PAYLOAD = joi.object().keys({
+  account_id: joi.number().integer(),
+  name: joi.string(),
+  parent_id: joi.number().integer()
+}).or('account_id', 'name', 'parent_id')
+
+const DELETE_PAYLOAD = joi.object().keys({
+  delete_children: joi.boolean()
+}).allow(null)
+
+exports.get = {
+  description: GET_DESCRIPTION,
+  validate: {
+    params: { id: joi.number().integer() }
+  },
+  plugins: { 'hapi-swagger': { responses: GENERAL_RESPONSES } },
+  handler: HANDLER
+}
+
+exports.put = {
+  description: PUT_DESCRIPTION,
+  validate: {
+    params: { id: joi.number().integer() },
+    payload: PUT_PAYLOAD
+  },
+  plugins: { 'hapi-swagger': { responses: GENERAL_RESPONSES } },
+  handler: HANDLER
+}
+
+exports.delete = {
+  description: DELETE_DESCRIPTION,
+  validate: {
+    params: { id: joi.number().integer() },
+    payload: DELETE_PAYLOAD
+  },
+  plugins: { 'hapi-swagger': { responses: DELETE_RESPONSES } },
+  handler: HANDLER
+}

--- a/handlers/categories.js
+++ b/handlers/categories.js
@@ -11,8 +11,28 @@ const GET_RESPONSES = {
     'schema': joi.array().items({
       id: joi.number().integer(),
       parent_id: joi.number().integer(),
+      account_id: joi.number().integer(),
       name: joi.string(),
     })
+  },
+  '500': {
+    'description': 'Server Error'
+  }
+}
+
+const POST_DESCRIPTION = 'Create New Categories'
+const POST_RESPONSES = {
+  '200': {
+    'description': 'Success',
+    'schema': joi.object().keys({
+      id: joi.number().integer(),
+      parent_id: joi.number().integer(),
+      account_id: joi.number().integer(),
+      name: joi.string(),
+    })
+  },
+  '401': {
+    'description': 'Not authorized to create for account or account does not exist'
   },
   '500': {
     'description': 'Server Error'
@@ -22,19 +42,83 @@ const GET_RESPONSES = {
 const GET_HANDLER = async (request, h) => {
   let userID = request.auth.credentials.user_id
   let accounts = await Time.Account.findForUser(userID)
-  let categories = await Promise.all(accounts.map(account =>
+  let categoriesForAccounts = await Promise.all(accounts.map(account =>
     Time.Category.findForAccount(account)
   ))
+
+  let categories = categoriesForAccounts.reduce((acc, cur) => acc.concat(cur), [])
 
   return categories.map(category => ({
     id: category.id,
     parent_id: category.props.parent_id,
+    account_id: category.props.account_id,
     name: category.name
   }))
 }
+
+const POST_HANDLER = async (request, h) => {
+  let userID = request.auth.credentials.user_id
+  let accounts = await Time.Account.findForUser(userID)
+
+  let validAccount = accounts.reduce((acc, cur) => {
+    let currentIsTarget = cur.id == request.payload.account_id
+    return acc || currentIsTarget
+  }, false)
+  let hasAccounts = accounts.length > 0
+  let allowedToAccess = hasAccounts && validAccount
+  if (!allowedToAccess) throw boom.unauthorized()
+
+  let account_id = request.payload.account_id
+  let name = request.payload.name
+  let parentID = request.payload.parent_id
+
+  let category = new Time.Category({ name, account_id })
+
+  if (parentID) {
+    let parent = await Time.Category.fetch(parentID).catch(() => null)
+    if (!parent) throw boom.badRequest()
+
+    category.parent = parent
+  }
+
+  try {
+    await category.save()
+
+    return {
+      id: category.id,
+      parent_id: category.props.parent_id,
+      account_id: category.props.account_id,
+      name: category.name
+    }
+  } catch (err) {
+    switch (err) {
+      case Time.Error.Category.INCONSISTENT_PARENT_AND_ACCOUNT:
+        throw boom.badRequest('Mismatched Parent and Account IDs')
+
+      // Note: Joi validation and checks above should prevent this.
+      case Time.Error.Data.NOT_FOUND:
+      case Time.Error.Category.INSUFFICIENT_PARENT_OR_ACCOUNT:
+      default:
+        throw boom.badImplementation()
+    }
+  }
+}
+
+const POST_PAYLOAD = joi.object().keys({
+  account_id: joi.number().integer().required(),
+  name: joi.string().required(),
+  parent_id: joi.number().integer()
+})
 
 exports.get = {
   description: GET_DESCRIPTION,
   plugins: { 'hapi-swagger': { responses: GET_RESPONSES } },
   handler: GET_HANDLER
+}
+
+exports.post = {
+  description: POST_DESCRIPTION,
+  plugins: { 'hapi-swagger': { responses: POST_RESPONSES } },
+  handler: POST_HANDLER,
+  validate: { payload: POST_PAYLOAD }
 }

--- a/handlers/categories.js
+++ b/handlers/categories.js
@@ -1,0 +1,40 @@
+const joi = require('joi')
+const boom = require('boom')
+const Time = require('time-core')()
+
+exports.path = '/categories'
+
+const GET_DESCRIPTION = 'Fetch All Categories'
+const GET_RESPONSES = {
+  '200': {
+    'description': 'Success',
+    'schema': joi.array().items({
+      id: joi.number().integer(),
+      parent_id: joi.number().integer(),
+      name: joi.string(),
+    })
+  },
+  '500': {
+    'description': 'Server Error'
+  }
+}
+
+const GET_HANDLER = async (request, h) => {
+  let userID = request.auth.credentials.user_id
+  let accounts = await Time.Account.findForUser(userID)
+  let categories = await Promise.all(accounts.map(account =>
+    Time.Category.findForAccount(account)
+  ))
+
+  return categories.map(category => ({
+    id: category.id,
+    parent_id: category.props.parent_id,
+    name: category.name
+  }))
+}
+
+exports.get = {
+  description: GET_DESCRIPTION,
+  plugins: { 'hapi-swagger': { responses: GET_RESPONSES } },
+  handler: GET_HANDLER
+}

--- a/handlers/categories.js
+++ b/handlers/categories.js
@@ -55,8 +55,8 @@ const GET_HANDLER = async (request, h) => {
 
   return categories.map(category => ({
     id: category.id,
-    parent_id: category.props.parent_id,
-    account_id: category.props.account_id,
+    parent_id: category.parent_id,
+    account_id: category.account_id,
     name: category.name
   }))
 }
@@ -100,8 +100,8 @@ const POST_HANDLER = async (request, h) => {
 
     return {
       id: category.id,
-      parent_id: category.props.parent_id,
-      account_id: category.props.account_id,
+      parent_id: category.parent_id,
+      account_id: category.account_id,
       name: category.name
     }
   } catch (err) {

--- a/handlers/categories.js
+++ b/handlers/categories.js
@@ -42,6 +42,11 @@ const POST_RESPONSES = {
 const GET_HANDLER = async (request, h) => {
   let userID = request.auth.credentials.user_id
   let accounts = await Time.Account.findForUser(userID)
+
+  let filterAccountIDs = request.query.account_id
+  if (filterAccountIDs)
+    accounts = accounts.filter(account => filterAccountIDs.includes(account.id))
+
   let categoriesForAccounts = await Promise.all(accounts.map(account =>
     Time.Category.findForAccount(account)
   ))
@@ -55,6 +60,10 @@ const GET_HANDLER = async (request, h) => {
     name: category.name
   }))
 }
+
+const GET_QUERY = joi.object().keys({
+  account_id: joi.array().items(joi.number().integer()).single()
+}).allow(null)
 
 const POST_HANDLER_REQUEST_VALIDATION = async (request, h) => {
   let userID = request.auth.credentials.user_id
@@ -118,7 +127,8 @@ const POST_PAYLOAD = joi.object().keys({
 exports.get = {
   description: GET_DESCRIPTION,
   plugins: { 'hapi-swagger': { responses: GET_RESPONSES } },
-  handler: GET_HANDLER
+  handler: GET_HANDLER,
+  validate: { query: GET_QUERY }
 }
 
 exports.post = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4871,7 +4871,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "p-finally": {
@@ -5578,10 +5578,10 @@
       }
     },
     "time-core": {
-      "version": "git+https://git@github.com/Tornquist/Time-Core.git#85745f31cad7abc00b3d85657b03b46fdc91f534",
-      "from": "git+https://git@github.com/Tornquist/Time-Core.git#v0.1.2",
+      "version": "git+https://git@github.com/Tornquist/Time-Core.git#24994bcc553d5aef6186801e486c71db6b11372e",
+      "from": "git+https://git@github.com/Tornquist/Time-Core.git#24994bc",
       "requires": {
-        "bcrypt": "^3.0.0",
+        "bcrypt": "3.0.0",
         "dotenv": "^6.0.0",
         "knex": "^0.15.2",
         "moment": "^2.22.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5578,8 +5578,8 @@
       }
     },
     "time-core": {
-      "version": "git+https://git@github.com/Tornquist/Time-Core.git#24994bcc553d5aef6186801e486c71db6b11372e",
-      "from": "git+https://git@github.com/Tornquist/Time-Core.git#24994bc",
+      "version": "git+https://git@github.com/Tornquist/Time-Core.git#71b28399e9c14406eca486ac2701bbf16037cf20",
+      "from": "git+https://git@github.com/Tornquist/Time-Core.git#v0.1.3",
       "requires": {
         "bcrypt": "3.0.0",
         "dotenv": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "inert": "^5.1.2",
     "joi": "^14.0.4",
     "require-dir": "^1.1.0",
-    "time-core": "git+https://git@github.com/Tornquist/Time-Core.git#24994bc",
+    "time-core": "git+https://git@github.com/Tornquist/Time-Core.git#v0.1.3",
     "vision": "^5.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "inert": "^5.1.2",
     "joi": "^14.0.4",
     "require-dir": "^1.1.0",
-    "time-core": "git+https://git@github.com/Tornquist/Time-Core.git#v0.1.2",
+    "time-core": "git+https://git@github.com/Tornquist/Time-Core.git#24994bc",
     "vision": "^5.4.3"
   },
   "devDependencies": {

--- a/test/helpers/account.js
+++ b/test/helpers/account.js
@@ -1,0 +1,25 @@
+const UUIDv4 = require('uuid/v4')
+const querystring = require('querystring')
+
+let storedTime = null;
+
+exports.link = (providedTime) => {
+  storedTime = providedTime
+}
+
+exports.create = async (userID, Time) => {
+  let newAccount = new (storedTime || Time).Account()
+  newAccount.register(userID)
+  await newAccount.save()
+
+  return newAccount
+}
+
+exports.getRootCategory = async (account, Time) => {
+  let categories = await (storedTime || Time).Category.findForAccount(account)
+  return categories.filter(category => category.name === "root")[0]
+}
+
+exports.cleanup = async (account = {}, Time) => {
+  await (storedTime || Time)._db('account').where('id', account.id).del()
+}

--- a/test/helpers/category.js
+++ b/test/helpers/category.js
@@ -1,0 +1,20 @@
+const UUIDv4 = require('uuid/v4')
+const querystring = require('querystring')
+
+let storedTime = null;
+
+exports.link = (providedTime) => {
+  storedTime = providedTime
+}
+
+exports.create = async (name, account = null, parent = null, Time) => {
+  let newCategory = new (storedTime || Time).Category()
+
+  newCategory.name = name
+  if (account) newCategory.account = account
+  if (parent) newCategory.parent = parent
+
+  await newCategory.save()
+
+  return newCategory
+}

--- a/test/test-categories.js
+++ b/test/test-categories.js
@@ -9,38 +9,22 @@ const querystring = require('querystring')
 // Initialize Time Core to seed DB as-needed
 const config = require('./setup/config')
 const Time = require('time-core')(config)
+
+const AccountHelper = require('./helpers/account')
+const CategoryHelper = require('./helpers/category')
 const UserHelper = require('./helpers/user')
 
 describe('Categories', function() {
   let server;
-
-  let userA, userB;
-  let tokenA, tokenB;
-
-  let userBAccountID;
-  let userBRootID;
-
-  let createdAccountID;
 
   before(async function() {
     this.timeout(5000)
 
     server = await require(process.env.PWD+'/server')
 
+    AccountHelper.link(Time)
+    CategoryHelper.link(Time)
     UserHelper.link(Time)
-    userA = await UserHelper.create()
-    tokenA = await UserHelper.login(userA, server)
-
-    userB = await UserHelper.create()
-    tokenB = await UserHelper.login(userB, server)
-
-    let accountResponse = await server.inject({
-      method: 'POST',
-      url: '/accounts',
-      headers: { 'Authorization': `Bearer ${tokenB}` }
-    })
-    userBAccountID = JSON.parse(accountResponse.payload).id
-    userBRootID = (await getCategories(tokenB)).payload[0].id
   })
 
   let getCategories = async (token) => {
@@ -55,9 +39,35 @@ describe('Categories', function() {
   }
 
   describe('Listing and creating', () => {
+    // Managed by before/acfer
+    let userA, userB;
+    let tokenA, tokenB;
+
+    let userBAccountID;
+    let userBRootID;
+
+    // Shared between tests
     let rootID;
     let childID;
     let accountID;
+
+    before(async function() {
+      this.timeout(5000)
+
+      userA = await UserHelper.create()
+      tokenA = await UserHelper.login(userA, server)
+
+      userB = await UserHelper.create()
+      tokenB = await UserHelper.login(userB, server)
+
+      let accountResponse = await server.inject({
+        method: 'POST',
+        url: '/accounts',
+        headers: { 'Authorization': `Bearer ${tokenB}` }
+      })
+      userBAccountID = JSON.parse(accountResponse.payload).id
+      userBRootID = (await getCategories(tokenB)).payload[0].id
+    })
 
     it('starts with no categories', async () => {
       let response = await getCategories(tokenA)
@@ -179,10 +189,356 @@ describe('Categories', function() {
       let message = JSON.parse(newCategory.payload).message
       message.should.eq('Mismatched Parent and Account IDs')
     })
+
+    after(async () => {
+      await UserHelper.cleanup(userA)
+      await UserHelper.cleanup(userB)
+    })
   })
 
-  after(async () => {
-    await UserHelper.cleanup(userA)
-    await UserHelper.cleanup(userB)
+  describe('Modifying categories', () => {
+    let userA, userB;
+    let tokenA, tokenB;
+    let accountA, accountB, accountC;
+    let rootA, rootB, rootC;
+    let a, b, c, d, e, f, g, h;
+
+    before(async function() {
+      this.timeout(10000)
+
+      userA = await UserHelper.create()
+      tokenA = await UserHelper.login(userA, server)
+      userB = await UserHelper.create()
+
+      /*
+          root A
+          ├── A
+          │   ├── B
+          │   │   ├── C
+          │   │   └── D
+          │   ├── E
+          │   └── F
+          └── G
+
+          root B
+          └── H
+      */
+
+      accountA = await AccountHelper.create(userA.user.id)
+      rootA = await AccountHelper.getRootCategory(accountA)
+
+      accountB = await AccountHelper.create(userA.user.id)
+      rootB = await AccountHelper.getRootCategory(accountB)
+
+      accountC = await AccountHelper.create(userB.user.id)
+      rootC = await AccountHelper.getRootCategory(accountC)
+
+      a = await CategoryHelper.create("A", accountA)
+      b = await CategoryHelper.create("B", accountA, a)
+      c = await CategoryHelper.create("C", accountA, b)
+      d = await CategoryHelper.create("D", accountA, b)
+      e = await CategoryHelper.create("E", accountA, a)
+      f = await CategoryHelper.create("F", accountA, a)
+      g = await CategoryHelper.create("G", accountA)
+      h = await CategoryHelper.create("H", accountB)
+    })
+
+    it('starts with the expected tree', async () => {
+      let categories = await getCategories(tokenA)
+
+      categories.payload.length.should.eq(10)
+      categories.payload.forEach((category) => {
+        switch (category.id) {
+          case a.id:
+            category.parent_id.should.eq(rootA.id)
+            break
+          case b.id:
+            category.parent_id.should.eq(a.id)
+            break
+          case c.id:
+            category.parent_id.should.eq(b.id)
+            break
+          case d.id:
+            category.parent_id.should.eq(b.id)
+            break
+          case e.id:
+            category.parent_id.should.eq(a.id)
+            break
+          case f.id:
+            category.parent_id.should.eq(a.id)
+            break
+          case g.id:
+            category.parent_id.should.eq(rootA.id)
+            break
+          case h.id:
+            category.parent_id.should.eq(rootB.id)
+            break
+          default:
+            category.name.should.eq('root')
+        }
+      })
+    })
+
+    describe('Validation', () => {
+      it('rejects actions on categories that do not exist', async () => {
+        let response = await server.inject({
+          method: 'GET',
+          url: '/categories/10000',
+          headers: { 'Authorization': `Bearer ${tokenA}` }
+        })
+
+        response.statusCode.should.eq(404)
+      })
+
+      it('rejects actions on categories the user does not have access to', async () => {
+        let response = await server.inject({
+          method: 'GET',
+          url: `/categories/${rootC.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` }
+        })
+
+        response.statusCode.should.eq(401)
+      })
+    })
+
+    describe('Basic updates', () => {
+      it('allows fetching a specific category', async () => {
+        let response = await server.inject({
+          method: 'GET',
+          url: `/categories/${a.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` }
+        })
+
+        response.statusCode.should.eq(200)
+        response.payload = JSON.parse(response.payload)
+        response.payload.name.should.eq("A")
+      })
+
+      it('allows changing a category\'s name', async () => {
+        let name = "Alphabet"
+        let response = await server.inject({
+          method: 'PUT',
+          url: `/categories/${a.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { name }
+        })
+
+        response.statusCode.should.eq(200)
+        response.payload = JSON.parse(response.payload)
+        response.payload.name.should.eq(name)
+      })
+
+      it('rejects empty updates', async () => {
+        let response = await server.inject({
+          method: 'PUT',
+          url: `/categories/${a.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { }
+        })
+
+        response.statusCode.should.eq(400)
+      })
+
+      it('allows fetching category updates', async () => {
+        let response = await server.inject({
+          method: 'GET',
+          url: `/categories/${a.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` }
+        })
+
+        response.statusCode.should.eq(200)
+        response.payload = JSON.parse(response.payload)
+        response.payload.name.should.eq("Alphabet")
+      })
+    })
+
+    describe('Moving categories', () => {
+      it('allows moving a category within the same account', async () => {
+        let response = await server.inject({
+          method: 'PUT',
+          url: `/categories/${f.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { parent_id: d.id }
+        })
+
+        response.statusCode.should.eq(200)
+        response.payload = JSON.parse(response.payload)
+        response.payload.name.should.eq("F")
+        response.payload.parent_id.should.eq(d.id)
+
+        let categories = await getCategories(tokenA)
+        let category = categories.payload.filter(category => category.id === f.id)[0]
+        category.parent_id.should.eq(d.id)
+      })
+
+      it('allows moving a category between accounts without a new parent', async () => {
+        let response = await server.inject({
+          method: 'PUT',
+          url: `/categories/${b.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { account_id: accountB.id }
+        })
+
+        response.statusCode.should.eq(200)
+        response.payload = JSON.parse(response.payload)
+        response.payload.name.should.eq("B")
+        response.payload.parent_id.should.eq(rootB.id)
+        response.payload.account_id.should.eq(accountB.id)
+
+        let categories = await getCategories(tokenA)
+
+        let bUp = categories.payload.find(category => category.id === b.id)
+        bUp.name.should.eq("B")
+        bUp.parent_id.should.eq(rootB.id)
+        bUp.account_id.should.eq(accountB.id)
+
+        let cUp = categories.payload.find(category => category.id === c.id)
+        cUp.name.should.eq("C")
+        cUp.parent_id.should.eq(b.id)
+        cUp.parent_id.should.eq(bUp.id)
+        cUp.account_id.should.eq(accountB.id)
+
+        let dUp = categories.payload.find(category => category.id === d.id)
+        dUp.name.should.eq("D")
+        dUp.parent_id.should.eq(b.id)
+        dUp.parent_id.should.eq(bUp.id)
+        dUp.account_id.should.eq(accountB.id)
+
+        let fUp = categories.payload.find(category => category.id === f.id)
+        fUp.name.should.eq("F")
+        fUp.parent_id.should.eq(d.id)
+        fUp.parent_id.should.eq(dUp.id)
+        fUp.account_id.should.eq(accountB.id)
+      })
+
+      it('allows moving a category between accounts to a specific parent', async () => {
+        let response = await server.inject({
+          method: 'PUT',
+          url: `/categories/${g.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { account_id: accountB.id, parent_id: h.id }
+        })
+
+        response.statusCode.should.eq(200)
+        response.payload = JSON.parse(response.payload)
+        response.payload.name.should.eq("G")
+        response.payload.parent_id.should.eq(h.id)
+        response.payload.account_id.should.eq(accountB.id)
+      })
+
+      it('denies moving categories to a mismatched parent and account', async () => {
+        let response = await server.inject({
+          method: 'PUT',
+          url: `/categories/${g.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { account_id: accountA.id, parent_id: f.id }
+        })
+
+        response.statusCode.should.eq(400)
+        let message = JSON.parse(response.payload).message
+        message.should.eq('Mismatched Parent and Account IDs')
+      })
+
+      it('denies moving categories to a parent the user does not have access to', async () => {
+        let response = await server.inject({
+          method: 'PUT',
+          url: `/categories/${g.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { parent_id: rootC.id }
+        })
+
+        response.statusCode.should.eq(401)
+      })
+
+      it('denies moving categories to an account the user does not have access to', async () => {
+        let response = await server.inject({
+          method: 'PUT',
+          url: `/categories/${g.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { account_id: accountC.id }
+        })
+
+        response.statusCode.should.eq(401)
+      })
+    })
+
+    describe('Deleting categories', () => {
+      it('allows deleting categories and preserving the children', async () => {
+        let response = await server.inject({
+          method: 'DELETE',
+          url: `/categories/${b.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` }
+        })
+        response.statusCode.should.eq(200)
+
+        let categories = await getCategories(tokenA)
+
+        let bUp = categories.payload.find(category => category.id === b.id)
+        should.equal(bUp, undefined)
+
+        let cUp = categories.payload.find(category => category.id === c.id)
+        cUp.name.should.eq("C")
+        cUp.parent_id.should.eq(rootB.id)
+        cUp.account_id.should.eq(accountB.id)
+
+        let dUp = categories.payload.find(category => category.id === d.id)
+        dUp.name.should.eq("D")
+        dUp.parent_id.should.eq(rootB.id)
+        dUp.account_id.should.eq(accountB.id)
+
+        let fUp = categories.payload.find(category => category.id === f.id)
+        fUp.name.should.eq("F")
+        fUp.parent_id.should.eq(d.id)
+        fUp.parent_id.should.eq(dUp.id)
+        fUp.account_id.should.eq(accountB.id)
+      })
+
+      it('allows deleting categories and the children', async () => {
+        let response = await server.inject({
+          method: 'DELETE',
+          url: `/categories/${d.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { delete_children: true }
+        })
+        response.statusCode.should.eq(200)
+
+        let categories = await getCategories(tokenA)
+
+        let dUp = categories.payload.find(category => category.id === d.id)
+        should.equal(dUp, undefined)
+
+        let fUp = categories.payload.find(category => category.id === f.id)
+        should.equal(fUp, undefined)
+      })
+
+      it('allows explicitely preserving children', async () => {
+        let response = await server.inject({
+          method: 'DELETE',
+          url: `/categories/${g.id}`,
+          headers: { 'Authorization': `Bearer ${tokenA}` },
+          payload: { delete_children: false }
+        })
+
+        response.statusCode.should.eq(200)
+
+        let categories = await getCategories(tokenA)
+
+        let gUp = categories.payload.find(category => category.id === g.id)
+        should.equal(gUp, undefined)
+
+        let hUp = categories.payload.find(category => category.id === h.id)
+        hUp.name.should.eq("H")
+        hUp.parent_id.should.eq(rootB.id)
+        hUp.account_id.should.eq(accountB.id)
+      })
+    })
+
+    after(async () => {
+      await AccountHelper.cleanup(accountA)
+      await AccountHelper.cleanup(accountB)
+
+      await UserHelper.cleanup(userA)
+      await UserHelper.cleanup(userB)
+    })
   })
 })

--- a/test/test-categories.js
+++ b/test/test-categories.js
@@ -1,0 +1,188 @@
+require('dotenv').config()
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const should = chai.should()
+const uuid = require('uuid/v4')
+const querystring = require('querystring')
+
+// Initialize Time Core to seed DB as-needed
+const config = require('./setup/config')
+const Time = require('time-core')(config)
+const UserHelper = require('./helpers/user')
+
+describe('Categories', function() {
+  let server;
+
+  let userA, userB;
+  let tokenA, tokenB;
+
+  let userBAccountID;
+  let userBRootID;
+
+  let createdAccountID;
+
+  before(async function() {
+    this.timeout(5000)
+
+    server = await require(process.env.PWD+'/server')
+
+    UserHelper.link(Time)
+    userA = await UserHelper.create()
+    tokenA = await UserHelper.login(userA, server)
+
+    userB = await UserHelper.create()
+    tokenB = await UserHelper.login(userB, server)
+
+    let accountResponse = await server.inject({
+      method: 'POST',
+      url: '/accounts',
+      headers: { 'Authorization': `Bearer ${tokenB}` }
+    })
+    userBAccountID = JSON.parse(accountResponse.payload).id
+    userBRootID = (await getCategories(tokenB)).payload[0].id
+  })
+
+  let getCategories = async (token) => {
+    let response = await server.inject({
+      method: 'GET',
+      url: '/categories',
+      headers: { 'Authorization': `Bearer ${token}` }
+    })
+
+    response.payload = JSON.parse(response.payload)
+    return response
+  }
+
+  describe('Listing and creating', () => {
+    let rootID;
+    let childID;
+    let accountID;
+
+    it('starts with no categories', async () => {
+      let response = await getCategories(tokenA)
+
+      response.statusCode.should.eq(200)
+      response.payload.length.should.eq(0)
+    })
+
+    it('creates a root category with every account created', async () => {
+      let accountResponse = await server.inject({
+        method: 'POST',
+        url: '/accounts',
+        headers: { 'Authorization': `Bearer ${tokenA}` }
+      })
+      accountID = JSON.parse(accountResponse.payload).id
+
+      let response = await getCategories(tokenA)
+
+      response.statusCode.should.eq(200)
+      response.payload.length.should.eq(1)
+
+      should.equal(response.payload[0].parent_id, null)
+      response.payload[0].name.should.eq("root")
+      rootID = response.payload[0].id
+    })
+
+    it('makes new categories without a parent children of the root category', async () => {
+      let newCategory = await server.inject({
+        method: 'POST',
+        url: '/categories',
+        headers: { 'Authorization': `Bearer ${tokenA}` },
+        payload: {
+          account_id: accountID,
+          name: 'My first category'
+        }
+      })
+
+      newCategory.statusCode.should.eq(200)
+      let createdCategory = JSON.parse(newCategory.payload)
+
+      createdCategory.parent_id.should.eq(rootID)
+      createdCategory.account_id.should.eq(accountID)
+      createdCategory.name.should.eq('My first category')
+      createdCategory.id.should.be.a('number')
+
+      childID = createdCategory.id
+    })
+
+    it('returns all categories after creating new ones', async () => {
+      let response = await getCategories(tokenA)
+
+      response.statusCode.should.eq(200)
+      response.payload.length.should.eq(2)
+    })
+
+    it('allows creating categories with a specified parent', async () => {
+      let newCategory = await server.inject({
+        method: 'POST',
+        url: '/categories',
+        headers: { 'Authorization': `Bearer ${tokenA}` },
+        payload: {
+          account_id: accountID,
+          name: 'My second category',
+          parent_id: childID
+        }
+      })
+
+      newCategory.statusCode.should.eq(200)
+      let createdCategory = JSON.parse(newCategory.payload)
+
+      createdCategory.parent_id.should.eq(childID)
+      createdCategory.account_id.should.eq(accountID)
+      createdCategory.name.should.eq('My second category')
+      createdCategory.id.should.be.a('number')
+    })
+
+    it('rejects creating categories with a parent that does not exist', async () => {
+      let newCategory = await server.inject({
+        method: 'POST',
+        url: '/categories',
+        headers: { 'Authorization': `Bearer ${tokenA}` },
+        payload: {
+          account_id: accountID,
+          name: 'My failing category',
+          parent_id: 1000000
+        }
+      })
+
+      newCategory.statusCode.should.eq(400)
+    })
+
+    it('rejects creating categories for unauthorized accounts', async () => {
+      let newCategory = await server.inject({
+        method: 'POST',
+        url: '/categories',
+        headers: { 'Authorization': `Bearer ${tokenA}` },
+        payload: {
+          account_id: userBAccountID,
+          name: 'My failing category'
+        }
+      })
+
+      newCategory.statusCode.should.eq(401)
+    })
+
+    it('rejects mismatched account and parent ids', async () => {
+      let newCategory = await server.inject({
+        method: 'POST',
+        url: '/categories',
+        headers: { 'Authorization': `Bearer ${tokenA}` },
+        payload: {
+          account_id: accountID,
+          name: 'My failing category',
+          parent_id: userBRootID
+        }
+      })
+
+      newCategory.statusCode.should.eq(400)
+      let message = JSON.parse(newCategory.payload).message
+      message.should.eq('Mismatched Parent and Account IDs')
+    })
+  })
+
+  after(async () => {
+    await UserHelper.cleanup(userA)
+    await UserHelper.cleanup(userB)
+  })
+})


### PR DESCRIPTION
## 💚 Summary

* Added `/categories` to create and retrieve all categories that are available to the current user
* Added `/categories/:id` to refresh, modify and delete specific categories

Details:

All requests (except for delete) return the specific category objects being manipulated. `POST /categories` returns only what was created. `PUT /categories/:id` returns only the category explicitly mentioned. (The one referenced with `:id`). For updates to children, the clients are expected to modify their local cache accordingly, and/or request updates as needed.

A nice improvement, would be to return a list of IDs that were modified by the action so that the client does not have to determine that on its own. However, given that the clients will be managing and holding a true tree structure in memory, the maintenance will be relatively cheap.