### PR TITLE
Client Auth Refresh

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -92,6 +92,12 @@ const authHandler = (request, h) => {
   .catch(err => {
     switch(err) {
       case Time.Error.Authentication.TOKEN_EXPIRED:
+        // Should only throw TOKEN_EXPIRED from refresh request
+        if (request.payload.grant_type === REFRESH_TOKEN_GRANT) {
+          return boom.unauthorized("Refresh expired")
+        } else {
+          return boom.unauthorized()
+        }
       case Time.Error.Authentication.TOKEN_INVALID:
       case Time.Error.Authentication.INVALID_PASSWORD:
         return boom.unauthorized()
@@ -120,8 +126,9 @@ let oauthScheme = (server, options) => ({
     }
     catch (err) {
       switch (err) {
-        case Time.Error.Authentication.UNIQUE_TOKEN_NOT_FOUND:
         case Time.Error.Authentication.TOKEN_EXPIRED:
+          return boom.unauthorized("Token expired")
+        case Time.Error.Authentication.UNIQUE_TOKEN_NOT_FOUND:
         case Time.Error.Authentication.TOKEN_INVALID:
           break
         default:

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -35,7 +35,7 @@ const ENDPOINT_RESPONSES = {
     'description': 'Invalid Type (internal), Token Not Found, Unique Token Not Found'
   },
   '401': {
-    'description': 'Token Expired, Token Invalid, Invalid Password'
+    'description': 'Token Expired, Token Invalid, Invalid Password. For expired refresh tokens, the message may contain `Refresh expired`'
   },
   '500': {
     'description': 'Server Error'
@@ -92,12 +92,8 @@ const authHandler = (request, h) => {
   .catch(err => {
     switch(err) {
       case Time.Error.Authentication.TOKEN_EXPIRED:
-        // Should only throw TOKEN_EXPIRED from refresh request
-        if (request.payload.grant_type === REFRESH_TOKEN_GRANT) {
-          return boom.unauthorized("Refresh expired")
-        } else {
-          return boom.unauthorized()
-        }
+        // Can only throw TOKEN_EXPIRED from refresh request
+        return boom.unauthorized("Refresh expired")
       case Time.Error.Authentication.TOKEN_INVALID:
       case Time.Error.Authentication.INVALID_PASSWORD:
         return boom.unauthorized()


### PR DESCRIPTION
# 💚 Summary

For `Time-Client` to automatically refresh the auth token, I needed additional details about why a request was `unauthorized`. I do not want to refresh the token for accessing data that isn't in the current scope (a bug could cause constant refreshes if I were to do this). 

This change introduces the ability to brute-force guess tokens and learn if that token was valid at some point. I'm going to ignore this slight decrease in security because:

1. It is necessary for the client to refresh tokens intelligently.
2. It is unlikely a token would be guessed. Tokens are randomly generated using dates, the PID of a given process, and `Math.random`.
3. Guessing a token does not give access to any data. There is no user information exposed through a token that has expired.